### PR TITLE
add: github-action to create release,

### DIFF
--- a/.github/workflows/release-ship.yaml
+++ b/.github/workflows/release-ship.yaml
@@ -1,0 +1,207 @@
+---
+name: Release Ship
+# From: https://github.com/actions-ecosystem/action-bump-semver
+# From: https://github.com/docker/build-push-action
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
+    branches: [main]
+env:
+  APP: microw
+  USER: ${{ github.repository_owner }}
+  EMAIL: ${{ github.repository_owner }}@users.noreply.github.com
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    outputs:
+      new_version: ${{ steps.bump-semver.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions-ecosystem/action-release-label@v1
+        id: release-label
+        if: ${{ steps.get-merged-pull-request.outputs.title != null }}
+        with:
+          labels: ${{ steps.get-merged-pull-request.outputs.labels }}
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1.4.1
+        id: get-latest-tag
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          semver_only: true
+
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: ${{ steps.release-label.outputs.level }}
+
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        with:
+          text: ${{ steps.get-merged-pull-request.outputs.body }}
+          regex: '```release_note([\s\S]*)```'
+
+      - uses: actions-ecosystem/action-push-tag@v1
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        with:
+          tag: ${{ steps.bump-semver.outputs.new_version }}
+          message: "${{ steps.bump-semver.outputs.new_version }}: PR #${{ steps.get-merged-pull-request.outputs.number }} ${{ steps.get-merged-pull-request.outputs.title }}"
+
+      - uses: actions/create-release@v1
+        if: ${{ steps.release-label.outputs.level == 'major' || steps.release-label.outputs.level == 'minor' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.bump-semver.outputs.new_version }}
+          release_name: ${{ steps.bump-semver.outputs.new_version }}
+          body: ${{ steps.regex-match.outputs.group1 }}
+
+      - uses: actions-ecosystem/action-create-comment@v1
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.get-merged-pull-request.outputs.number }}
+          body: |
+            The new version [${{ steps.bump-semver.outputs.new_version }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump-semver.outputs.new_version }}) has been released :tada:
+
+  ship:
+    needs: [release]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1.10.0 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1.10.0 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Extract major and minor version from semver
+      # Snippet from: https://github.com/actions/toolkit/blob/master/docs/commands.md#set-an-environment-variable
+        id: maj-min-version
+        shell: bash
+        run: |
+          TAG_MAJ=$(echo ${{ needs.release.outputs.new_version }} | cut -f 1 -d '.')
+          TAG_MIN=$(echo ${{ needs.release.outputs.new_version }} | cut -f 1,2 -d '.')
+          echo "::set-output name=tag_maj::$TAG_MAJ"
+          echo "::set-output name=tag_min::$TAG_MIN"
+
+      - name: Build and push arm32v7
+        uses: docker/build-push-action@v2
+        if: ${{ needs.release.outputs.new_version != null }}
+        with:
+          context: .
+          platforms: linux/arm/v7
+          push: true
+          labels: |
+            name: ${{ env.APP }}
+            maintainer: ${{ env.USER }} <${{ env.EMAIL }}>
+            version: ${{ needs.release.outputs.new_version }}
+            architecture: arm32v7
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:latest-armhf
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}-armhf
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}-armhf
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}-armhf
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:latest-armhf
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}-armhf
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}-armhf
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}-armhf
+
+      - name: Build and push arm64v8
+        uses: docker/build-push-action@v2
+        if: ${{ needs.release.outputs.new_version != null }}
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          labels: |
+            name: ${{ env.APP }}
+            maintainer: ${{ env.USER }} <${{ env.EMAIL }}>
+            version: ${{ needs.release.outputs.new_version }}
+            architecture: arm64v8
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:latest-arm64
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}-arm64
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}-arm64
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}-arm64
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:latest-arm64
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}-arm64
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}-arm64
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}-arm64
+
+      - name: Build and push amd64
+        uses: docker/build-push-action@v2
+        if: ${{ needs.release.outputs.new_version != null }}
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          labels: |
+            name: ${{ env.APP }}
+            maintainer: ${{ env.USER }} <${{ env.EMAIL }}>
+            version: ${{ needs.release.outputs.new_version }}
+            architecture: amd64
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}
+
+      - name: Build and push i386
+        uses: docker/build-push-action@v2
+        if: ${{ needs.release.outputs.new_version != null }}
+        with:
+          context: .
+          platforms: linux/386
+          push: true
+          labels: |
+            name: ${{ env.APP }}
+            maintainer: ${{ env.USER }} <${{ env.EMAIL }}>
+            version: ${{ needs.release.outputs.new_version }}
+            architecture: i386
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}-i386
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}-i386
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}-i386
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:latest-i386
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ needs.release.outputs.new_version }}-i386
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_maj }}-i386
+            ghcr.io/${{ github.repository_owner }}/${{ env.APP }}:${{ steps.maj-min-version.outputs.tag_min }}-i386
+
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP }}


### PR DESCRIPTION
Added Github-action to bump semvers corresponding to pr label, create a release on minor and major bumps, build images on major/minor/patches and upload the resulting artifacts to Dockerhub and Github container registries.