### PR TITLE
fix: ifs needs not allowing docker build to run

### DIFF
--- a/.github/workflows/semver-build-push-release.yaml
+++ b/.github/workflows/semver-build-push-release.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and push amd64
         uses: docker/build-push-action@v2
-        if: ${{ needs.jobs.semver.outputs.new_version != null }}
+        if: ${{ needs.jobs.semver.outputs.new_version }}
         with:
           context: .
           platforms: ${{ env.PLATFORM }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Build amd64
         uses: docker/build-push-action@v2
-        if: ${{ needs.jobs.semver.outputs.new_version != null }}
+        if: ${{ needs.jobs.semver.outputs.new_version }}
         with:
           context: .
           platforms: linux/amd64
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build arm64
         uses: docker/build-push-action@v2
-        if: ${{ needs.jobs.semver.outputs.new_version != null }}
+        if: ${{ needs.jobs.semver.outputs.new_version }}
         with:
           context: .
           platforms: linux/arm64
@@ -162,7 +162,7 @@ jobs:
 
       - name: Build armv7
         uses: docker/build-push-action@v2
-        if: ${{ needs.jobs.semver.outputs.new_version != null }}
+        if: ${{ needs.jobs.semver.outputs.new_version }}
         with:
           context: .
           platforms: linux/arm/v7
@@ -178,7 +178,7 @@ jobs:
 
       - name: Build i386
         uses: docker/build-push-action@v2
-        if: ${{ needs.jobs.semver.outputs.new_version != null }}
+        if: ${{ needs.jobs.semver.outputs.new_version }}
         with:
           context: .
           platforms: linux/386
@@ -221,13 +221,13 @@ jobs:
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex-match
-        if: ${{ needs.jobs.semver.outputs.new_version != null }}
+        if: ${{ needs.jobs.semver.outputs.new_version }}
         with:
           text: ${{ needs.jobs.semver.steps.get-merged-pull-request.outputs.body }}
           regex: '```release_note([\s\S]*)```'
 
       - uses: actions-ecosystem/action-push-tag@v1
-        if: ${{ needs.jobs.semver.outputs.new_version != null }}
+        if: ${{ needs.jobs.semver.outputs.new_version }}
         with:
           tag: ${{ needs.jobs.semver.outputs.new_version }}
           message: "${{ needs.jobs.semver.outputs.new_version }}: PR #${{ needs.jobs.semver.steps.get-merged-pull-request.outputs.number }} ${{ needs.jobs.semver.steps.get-merged-pull-request.outputs.title }}"


### PR DESCRIPTION
In the build pipeline the if: ${{ needs.jobs.semver.outputs.new_version !=null }} isn't allowing the build step to run, which is causing the pipeline to fail. This might fix that.